### PR TITLE
[Fix] fixes #10

### DIFF
--- a/library/src/main/java/me/weishu/epic/art/entry/Entry.java
+++ b/library/src/main/java/me/weishu/epic/art/entry/Entry.java
@@ -289,6 +289,12 @@ public class Entry {
                         if (arg1TypeLength == 4 && arg2TypeLength == 8) {
                             isR3Grabbed = false;
                         }
+
+                        if (numberOfArgs == 2 && arg1TypeLength == 8 && arg2TypeLength == 8) {
+                            // in this case, we have no reference register to local r3, just hard code now :(
+                            System.arraycopy(EpicNative.get(sp + 44, 4), 0, argBytes, 12, 4);
+                            isR3Grabbed = false;
+                        }
                     }
                     if (numberOfArgs >= 3) {
                         int arg1TypeLength = getTypeLength(typeOfArgs[0]);


### PR DESCRIPTION
In Android M's thumb2 mode, We can not locate the r3 register precisely, So we just search the registers behinds r3 to locate it. But in (QWORD, QWORD) mode, we have no remain register to reference, and may search a invalid value; We just hard code the offset now : )